### PR TITLE
Release Elixir version requirement

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Airbrake.Mixfile do
   def project do
     [app: :airbrake,
      version: "0.1.0",
-     elixir: "~> 1.0.0",
+     elixir: "~> 1.0",
      package: package,
      description: """
        An Elixir notifier to the Airbrake


### PR DESCRIPTION
Since Elixir uses SemVer, specifying `~> 1.0` as elixir version sholud be enough.
 `~> 1.0.0` generates warnings for anyone using this library on Elixir 1.1 and later.
