### PR TITLE
Configurable host

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ end
 # Open up your config/config.exs (or appropriate project config)
 config :airbrake, 
   api_key: "c191b51ee8c4feb0b50193c85d8d02a5",
-  project_id: 112696
+  project_id: 112696,
+  host: "http://collect.airbrake.io"
 ```
 
 ## Usage

--- a/config/config.exs
+++ b/config/config.exs
@@ -2,4 +2,5 @@ use Mix.Config
 
 config :airbrake,
   api_key: System.get_env("AIRBRAKE_API_KEY") || "FAKEKEY",
-  project_id: System.get_env("AIRBRAKE_PROJECT_ID") || 0
+  project_id: System.get_env("AIRBRAKE_PROJECT_ID") || 0,
+  host: System.get_env("AIRBRAKE_HOST") || "http://collect.airbrake.io"

--- a/lib/airbrake.ex
+++ b/lib/airbrake.ex
@@ -20,6 +20,7 @@ defmodule Airbrake do
   defp notify_url do
     project_id = Application.get_env(:airbrake, :project_id)
     api_key = Application.get_env(:airbrake, :api_key)
-    "http://collect.airbrake.io/api/v3/projects/#{project_id}/notices?key=#{api_key}"
+    host = Application.get_env(:airbrake, :host)
+    "#{host}/api/v3/projects/#{project_id}/notices?key=#{api_key}"
   end
 end

--- a/test/airbrake/payload_test.exs
+++ b/test/airbrake/payload_test.exs
@@ -67,7 +67,7 @@ defmodule Airbrake.PayloadTest do
   end
 
   test "it reports the error message" do
-    assert "undefined function: Harbour.cats/1 (module Harbour is not available)" == get_error.message
+    assert "undefined function Harbour.cats/1 (module Harbour is not available)" == get_error.message
   end
 
   test "it reports the notifier" do


### PR DESCRIPTION
Sometimes people use hosted errors trackers like Errbit which is compatible with Airbrake API. For those cases it'll be very convenient to have configurable host. 
