### PR TITLE
Allow configuration via {:system, var} tuples

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -1,6 +1,6 @@
 use Mix.Config
 
 config :airbrake,
-  api_key: System.get_env("AIRBRAKE_API_KEY") || "FAKEKEY",
-  project_id: System.get_env("AIRBRAKE_PROJECT_ID") || 0,
-  host: System.get_env("AIRBRAKE_HOST") || "http://collect.airbrake.io"
+  api_key: {:system, "AIRBRAKE_API_KEY", "FAKEKEY"},
+  project_id: {:system, "AIRBRAKE_PROJECT_ID", 0},
+  host: {:system, "AIRBRAKE_HOST", "http://collect.airbrake.io"}

--- a/lib/airbrake/logger_backend.ex
+++ b/lib/airbrake/logger_backend.ex
@@ -1,6 +1,6 @@
 defmodule Airbrake.LoggerBackend do
   @moduledoc false
-  use GenEvent
+  @behaviour :gen_event
 
   def init({__MODULE__, _name}) do
     {:ok, nil}
@@ -9,7 +9,6 @@ defmodule Airbrake.LoggerBackend do
   def handle_call(_, state) do
     {:ok, :ok, state}
   end
-
 
   def handle_event({_level, gl, _event}, state)
       when node(gl) != node() do
@@ -32,6 +31,17 @@ defmodule Airbrake.LoggerBackend do
     {:ok, state}
   end
 
+  def handle_info(_message, state) do
+    {:noreply, state}
+  end
+
+  def terminate(_reason, _state) do
+    :ok
+  end
+
+  def code_change(_old, state, _extra) do
+    {:ok, state}
+  end
 
   defp parse_error_message(msg) do
     msg 

--- a/lib/airbrake/payload.ex
+++ b/lib/airbrake/payload.ex
@@ -43,6 +43,7 @@ defmodule Airbrake.Payload do
   defp env do
     case Application.get_env(:airbrake, :environment) do
       nil -> hostname()
+      {:system, var} -> System.get_env(var) || hostname()
       atom_env when is_atom(atom_env) -> to_string(atom_env)
       str_env when is_binary(str_env) -> str_env
       fun_env when is_function(fun_env) -> fun_env.()

--- a/lib/airbrake/plug.ex
+++ b/lib/airbrake/plug.ex
@@ -19,7 +19,7 @@ defmodule Airbrake.Plug do
           httpMethod: conn.method
         }
 
-        Airbrake.Worker.remember(exception, [
+        Airbrake.Worker.report(exception, [
           params: conn.params,
           session: conn.private[:plug_session],
           context: conn_data,

--- a/mix.exs
+++ b/mix.exs
@@ -27,7 +27,7 @@ defmodule Airbrake.Mixfile do
 
   defp deps do
     [{:httpoison, "~> 0.9"},
-     {:poison, "~> 2.0"},
+     {:poison, "~> 2.0 or ~> 3.0"},
      {:ex_doc, ">= 0.0.0", only: :dev}]
   end
 end


### PR DESCRIPTION
`Airbrake` module documentation states that it is possible to configure it via `{:system, var}` tuples, but it is not true. This PR adds support for such tuples.