### PR TITLE
Fix Airbrake.Plug

### DIFF
--- a/lib/airbrake/plug.ex
+++ b/lib/airbrake/plug.ex
@@ -4,29 +4,33 @@ defmodule Airbrake.Plug do
     quote location: :keep do
       use Plug.ErrorHandler
 
-      defp handle_errors(conn, %{kind: _level, reason: exception, stack: stacktrace}) do
-        conn = conn |> Plug.Conn.fetch_cookies |> Plug.Conn.fetch_query_params
+      defp handle_errors(conn, %{kind: :error, reason: exception, stack: stacktrace}) do
+        conn = conn |> Plug.Conn.fetch_cookies() |> Plug.Conn.fetch_query_params()
         headers = Enum.into(conn.req_headers, %{})
 
         conn_data = %{
           url: "#{conn.scheme}://#{conn.host}:#{conn.port}#{conn.request_path}",
-          userIP: (conn.remote_ip |> Tuple.to_list() |> Enum.join(".")),
+          userIP: conn.remote_ip |> Tuple.to_list() |> Enum.join("."),
           userAgent: headers["user-agent"],
           cookies: conn.req_cookies
         }
+
         environment = %{
           headers: headers,
           httpMethod: conn.method
         }
 
-        Airbrake.Worker.remember(exception, [
+        Airbrake.Worker.remember(
+          exception,
           params: conn.params,
           session: conn.private[:plug_session],
           context: conn_data,
           env: environment,
           stacktrace: stacktrace
-        ])
+        )
       end
+
+      defp handle_errors(_conn, _map), do: nil
     end
   end
 end

--- a/lib/airbrake/worker.ex
+++ b/lib/airbrake/worker.ex
@@ -85,7 +85,8 @@ defmodule Airbrake.Worker do
   defp send_report(exception, stacktrace, options) do
     unless ignore?(exception) do
       payload = Airbrake.Payload.new(exception, stacktrace, options)
-      HTTPoison.post(notify_url(), Poison.encode!(payload), @request_headers)
+      json_encoder = Application.get_env(:airbrake, :json_encoder, Poison)
+      HTTPoison.post(notify_url(), json_encoder.encode!(payload), @request_headers)
     end
   end
 

--- a/lib/airbrake/worker.ex
+++ b/lib/airbrake/worker.ex
@@ -51,6 +51,8 @@ defmodule Airbrake.Worker do
     [type: inspect(exception.__struct__), message: Exception.message(exception)]
   end
 
+  def init(state), do: {:ok, state}
+
   def handle_cast({:report, exception, stacktrace, options}, %{last_exception: {exception, details}} = state) do
     enhanced_options = Enum.reduce([:context, :params, :session, :env], options, fn(key, enhanced_options) ->
       Keyword.put(enhanced_options, key, Map.merge(options[key] || %{}, details[key] || %{}))

--- a/mix.exs
+++ b/mix.exs
@@ -26,8 +26,10 @@ defmodule Airbrake.Mixfile do
   end
 
   defp deps do
-    [{:httpoison, "~> 0.9"},
-     {:poison, "~> 2.0 or ~> 3.0"},
-     {:ex_doc, ">= 0.0.0", only: :dev}]
+    [
+      {:httpoison, "~> 0.9"},
+      {:poison, "~> 2.0 or ~> 3.0", optional: true},
+      {:ex_doc, ">= 0.0.0", only: :dev}
+    ]
   end
 end


### PR DESCRIPTION
Airbrake.Plug currently doesn't check the type of the error coming through. For errors with types other than `:error` the `reason` is not an exception, so `Airbrake.Plug` ends up generating an error.

With these changes `Airbrake.Plug` will ignore anything that is not an `:error`.