### PR TITLE
Add ability to specify reporting options in configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,33 @@ config :airbrake,
   ignore: :all # to disable reporting
 ```
 
+## Shared options for reporting data to Airbrake
+
+To include with every report to Airbrake a set of optional data, include the `:options` key in the config. This can either
+be a keyword list of options or a function that returns a keyword list of options. Keyword list keys that can be used are
+`:context`, `:params`, `:session`, and `:env`.
+
+### Options function in config
+
+A function for creating options for reporting should be declared in the config as a tuple of 
+`{ModuleName, :function_name}`. This function should take as an argument a keyword list, possibly empty and should
+return a keyword list.
+
+```elixir
+config :airbrake,
+  options: {Web, :airbrake_options}
+```
+
+### Options keyword list in config
+
+When options are provided as a keyword list in the configuration and a specific call to `Airbrake.report/2` includes 
+options in its parameters, the options will be merged, with the parameters taking precedence.
+
+```elixir
+config :airbrake,
+  options: [env: %{"SOME_ENVIRONMENT_VARIABLE" => "environment variable"}]
+```
+
 
 ## Custom usage examples
 

--- a/README.md
+++ b/README.md
@@ -78,12 +78,12 @@ be a keyword list of options or a function that returns a keyword list of option
 ### Options function in config
 
 A function for creating options for reporting should be declared in the config as a tuple of 
-`{ModuleName, :function_name}`. This function should take as an argument a keyword list, possibly empty and should
-return a keyword list.
+`{ModuleName, :function_name, 1}`. This function should take as an argument a keyword list, possibly empty and should
+return a keyword list. The function arity is always 1.
 
 ```elixir
 config :airbrake,
-  options: {Web, :airbrake_options}
+  options: {Web, :airbrake_options, 1}
 ```
 
 ### Options keyword list in config

--- a/lib/airbrake/worker.ex
+++ b/lib/airbrake/worker.ex
@@ -93,8 +93,8 @@ defmodule Airbrake.Worker do
 
   defp build_options(current_options) do
     case get_env(:options) do
-      base_options when is_function(base_options, 1) ->
-        base_options.(current_options)
+      {mod, fun} ->
+        apply(mod, fun, [current_options])
       shared_options when is_list(shared_options) ->
         Keyword.merge(shared_options, current_options)
       _ ->

--- a/lib/airbrake/worker.ex
+++ b/lib/airbrake/worker.ex
@@ -84,9 +84,21 @@ defmodule Airbrake.Worker do
 
   defp send_report(exception, stacktrace, options) do
     unless ignore?(exception) do
-      payload = Airbrake.Payload.new(exception, stacktrace, options)
+      enhanced_options = build_options(options)
+      payload = Airbrake.Payload.new(exception, stacktrace, enhanced_options)
       json_encoder = Application.get_env(:airbrake, :json_encoder, Poison)
       HTTPoison.post(notify_url(), json_encoder.encode!(payload), @request_headers)
+    end
+  end
+
+  defp build_options(current_options) do
+    case get_env(:options) do
+      base_options when is_function(base_options, 1) ->
+        base_options.(current_options)
+      shared_options when is_list(shared_options) ->
+        Keyword.merge(shared_options, current_options)
+      _ ->
+        current_options
     end
   end
 

--- a/lib/airbrake/worker.ex
+++ b/lib/airbrake/worker.ex
@@ -93,7 +93,7 @@ defmodule Airbrake.Worker do
 
   defp build_options(current_options) do
     case get_env(:options) do
-      {mod, fun} ->
+      {mod, fun, 1} ->
         apply(mod, fun, [current_options])
       shared_options when is_list(shared_options) ->
         Keyword.merge(shared_options, current_options)


### PR DESCRIPTION
This pull request addresses #10 

This change adds the ability to set in the configuration the `options` that are sent in an Airbrake report. This allows for three things that are currently not possible.

1. The ability to have options set when a general error triggers an Airbrake report via the `Airbrake.LoggerBackend`.
2. The ability to have options set when `Airbrake.Plug` sends an error report to Airbrake.
3. The ability set options for reporting on a per-application basis without having to explicitly add `options` to each call to `Airbrake.report/2`. This reduces code duplication in applications that use this library.

For me, the most relevant use is reporting environment variables via the `:env` options key. The environment variables are useful in reporting for me. Because a server's environment variables are constant, having a way to declare or derive them once simplifies my use of this library.

## Examples of usage

### Report when using a function to set the options

One option is to define a function that creates the "options" to be provided in an Airbrake report.

Configuration snippet
```elixir
config :airbrake,
  ...
  options: {Web.Helper, :airbrake_options},
...
  logger_level: :error
```

Here how that function might look in the application using the library
```elixir
defmodule Web.Helper do
  @moduledoc """
  Helper functions for Web.
  """
...
  @spec airbrake_options(Keyword.t()) :: Keyword.t()
  def airbrake_options(options) do
    shared = [
      env: %{
        "KUBERNETES_ENVIRONMENT" => System.get_env("KUBERNETES_ENVIRONMENT"),
        "KUBERNETES_NAMESPACE" => System.get_env("KUBERNETES_NAMESPACE")
      }
    ]

    Keyword.merge(shared, options)
  end
end
```

Here is a snippet of a screenshot showing how this is reported
![Screen Shot 2019-09-05 at 10 00 14 AM](https://user-images.githubusercontent.com/15874832/64353851-07a05b00-cfc4-11e9-8fcb-4c59d57eb66c.png)


### Report when using a keyword list to set the options

The second option is to define a function that creates the "options" to be provided in an Airbrake report.

Configuration snippet
```elixir
config :airbrake,
  ...
  options: [
    env: %{
      "KUBERNETES_ENVIRONMENT" => System.get_env("KUBERNETES_ENVIRONMENT"),
      "KUBERNETES_NAMESPACE" => System.get_env("KUBERNETES_NAMESPACE")
    }
  ],
...
  logger_level: :error
```

Here is a snippet of a screenshot showing how this is reported
![Screen Shot 2019-09-05 at 10 00 01 AM](https://user-images.githubusercontent.com/15874832/64353862-0b33e200-cfc4-11e9-889a-f8eef6d0f7bb.png)

