### PR TITLE
Replace deprecated GenEvent with Erlang's :gen_event

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /_build
 /deps
+/cover
 erl_crash.dump
 *.ez
 mix.lock

--- a/config/config.exs
+++ b/config/config.exs
@@ -3,4 +3,7 @@ use Mix.Config
 config :airbrake,
   api_key: {:system, "AIRBRAKE_API_KEY", "FAKEKEY"},
   project_id: {:system, "AIRBRAKE_PROJECT_ID", 0},
-  host: {:system, "AIRBRAKE_HOST", "https://airbrake.io"}
+  host: {:system, "AIRBRAKE_HOST", "https://airbrake.io"},
+  http_adapter: HTTPoison
+
+import_config "#{Mix.env()}.exs"

--- a/config/config.exs
+++ b/config/config.exs
@@ -4,6 +4,6 @@ config :airbrake,
   api_key: {:system, "AIRBRAKE_API_KEY", "FAKEKEY"},
   project_id: {:system, "AIRBRAKE_PROJECT_ID", 0},
   host: {:system, "AIRBRAKE_HOST", "https://airbrake.io"},
-  http_adapter: HTTPoison
+  private: [http_adapter: HTTPoison]
 
 import_config "#{Mix.env()}.exs"

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -1,0 +1,1 @@
+use Mix.Config

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -1,0 +1,1 @@
+use Mix.Config

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,4 +1,4 @@
 use Mix.Config
 
 config :airbrake,
-  http_adapter: Airbrake.HTTPMock
+  private: [http_adapter: Airbrake.HTTPMock]

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,0 +1,4 @@
+use Mix.Config
+
+config :airbrake,
+  http_adapter: Airbrake.HTTPMock

--- a/coveralls.json
+++ b/coveralls.json
@@ -1,0 +1,6 @@
+{
+  "skip_files": [
+    "deps",
+    "test"
+  ]
+}

--- a/lib/airbrake/logger_backend.ex
+++ b/lib/airbrake/logger_backend.ex
@@ -10,7 +10,6 @@ defmodule Airbrake.LoggerBackend do
     {:ok, :ok, state}
   end
 
-
   def handle_event({_level, gl, _event}, state)
       when node(gl) != node() do
     {:ok, state}
@@ -19,45 +18,52 @@ defmodule Airbrake.LoggerBackend do
   def handle_event({:error, _, {Logger, msg, _ts, _metadata}}, state) do
     try do
       err_info = parse_error_message(msg)
-      Airbrake.report(err_info[:exception], [
+
+      Airbrake.report(err_info[:exception],
         stacktrace: err_info[:stacktrace] || [],
         context: err_info[:context]
-      ])
+      )
     rescue
       exception -> IO.inspect(exception)
     end
+
     {:ok, state}
   end
+
   def handle_event(_, state) do
     {:ok, state}
   end
 
-
   defp parse_error_message(msg) do
-    msg 
+    msg
     |> to_string
     |> String.split("\n")
-    |> Enum.reverse
+    |> Enum.reverse()
     |> Enum.reduce(%{stacktrace: [], context: %{}}, &parse_line/2)
   end
 
   defp parse_line("    " <> line, res), do: parse_line(line, res)
-  defp parse_line("** "  <> err_msg, res) do
+
+  defp parse_line("** " <> err_msg, res) do
     case Regex.run(~r/\((.*?)\)\s*(.*?)\z/, err_msg) do
       [_, type, message] ->
-        Map.put_new(res, :exception, [type: type, message: message])
+        Map.put_new(res, :exception, type: type, message: message)
+
       _ ->
-        Map.put_new(res, :exception, [type: "RuntimeError", message: err_msg])
+        Map.put_new(res, :exception, type: "RuntimeError", message: err_msg)
     end
   end
+
   defp parse_line("(" <> _ = st_line, res) do
     Map.put(res, :stacktrace, [st_line | Map.get(res, :stacktrace, [])])
   end
+
   defp parse_line(line, res) do
     case String.split(line, ": ", parts: 2) do
       [key, value] ->
-        key = key |> String.downcase |> String.to_atom
+        key = key |> String.downcase() |> String.to_atom()
         put_in(res, [:context, key], value)
+
       [value] ->
         put_in(res, [:context, :title], value)
     end

--- a/lib/airbrake/logger_backend.ex
+++ b/lib/airbrake/logger_backend.ex
@@ -1,6 +1,7 @@
 defmodule Airbrake.LoggerBackend do
   @moduledoc false
-  use GenEvent
+
+  @behaviour :gen_event
 
   def init({__MODULE__, _name}) do
     {:ok, nil}

--- a/lib/airbrake/worker.ex
+++ b/lib/airbrake/worker.ex
@@ -10,7 +10,9 @@ defmodule Airbrake.Worker do
   @name __MODULE__
   @request_headers [{"Content-Type", "application/json"}]
   @default_host "https://airbrake.io"
-  @http_adapter Application.get_env(:airbrake, :http_adapter)
+  @http_adapter :airbrake
+                |> Application.get_env(:private, [])
+                |> Keyword.get(:http_adapter, HTTPoison)
 
   @doc """
   Send a report to Airbrake.

--- a/lib/airbrake/worker.ex
+++ b/lib/airbrake/worker.ex
@@ -10,6 +10,7 @@ defmodule Airbrake.Worker do
   @name __MODULE__
   @request_headers [{"Content-Type", "application/json"}]
   @default_host "https://airbrake.io"
+  @http_adapter Application.get_env(:airbrake, :http_adapter)
 
   @doc """
   Send a report to Airbrake.
@@ -96,7 +97,7 @@ defmodule Airbrake.Worker do
       enhanced_options = build_options(options)
       payload = Airbrake.Payload.new(exception, stacktrace, enhanced_options)
       json_encoder = Application.get_env(:airbrake, :json_encoder, Poison)
-      HTTPoison.post(notify_url(), json_encoder.encode!(payload), @request_headers)
+      @http_adapter.post(notify_url(), json_encoder.encode!(payload), @request_headers)
     end
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -12,7 +12,14 @@ defmodule Airbrake.Mixfile do
         System-wide error reporting enriched with the information from Plug and Phoenix channels.
       """,
       deps: deps(),
-      docs: [main: "Airbrake"]
+      docs: [main: "Airbrake"],
+      preferred_cli_env: [
+        coveralls: :test,
+        "coveralls.detail": :test,
+        "coveralls.post": :test,
+        "coveralls.html": :test
+      ],
+      test_coverage: [tool: ExCoveralls]
     ]
   end
 
@@ -32,8 +39,10 @@ defmodule Airbrake.Mixfile do
   defp deps do
     [
       {:httpoison, "~> 0.9 or ~> 1.0"},
+      {:mox, "~> 0.5", only: :test},
       {:poison, ">= 2.0.0", optional: true},
-      {:ex_doc, "~> 0.19", only: :dev}
+      {:ex_doc, "~> 0.19", only: :dev},
+      {:excoveralls, "~> 0.12.0", only: :test}
     ]
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -6,6 +6,7 @@ defmodule Airbrake.Mixfile do
       app: :airbrake,
       version: "0.6.2",
       elixir: "~> 1.7",
+      elixirc_paths: elixirc_paths(Mix.env()),
       package: package(),
       description: """
         The first Elixir notifier to the Airbrake/Errbit.
@@ -35,6 +36,9 @@ defmodule Airbrake.Mixfile do
   def application do
     [mod: {Airbrake, []}, applications: [:httpoison]]
   end
+
+  defp elixirc_paths(:test), do: ["lib", "test/support"]
+  defp elixirc_paths(_), do: ["lib"]
 
   defp deps do
     [

--- a/mix.exs
+++ b/mix.exs
@@ -8,6 +8,7 @@ defmodule Airbrake.Mixfile do
       elixir: "~> 1.7",
       elixirc_paths: elixirc_paths(Mix.env()),
       package: package(),
+      aliases: aliases(),
       description: """
         The first Elixir notifier to the Airbrake/Errbit.
         System-wide error reporting enriched with the information from Plug and Phoenix channels.
@@ -47,6 +48,12 @@ defmodule Airbrake.Mixfile do
       {:poison, ">= 2.0.0", optional: true},
       {:ex_doc, "~> 0.19", only: :dev},
       {:excoveralls, "~> 0.12.0", only: :test}
+    ]
+  end
+
+  defp aliases do
+    [
+      test: "test --no-start"
     ]
   end
 end

--- a/test/airbrake/logger_backend_test.exs
+++ b/test/airbrake/logger_backend_test.exs
@@ -1,0 +1,38 @@
+defmodule Airbrake.LoggerBackendTest do
+  use ExUnit.Case, async: false
+
+  import Mox
+  import ExUnit.CaptureLog
+  require Logger
+
+  alias Airbrake.{LoggerBackend, HTTPMock}
+
+  setup [:set_mox_global, :verify_on_exit!]
+
+  setup do
+    Logger.add_backend({LoggerBackend, :error})
+    :ok
+  end
+
+  describe "error handling" do
+    test "sends the error via the HTTP handler" do
+      caller = self()
+      error_message = "** (FunctionClauseError) no function clause matching in Enum.join/2"
+
+      expected_payload_errors =
+        "\"errors\":[{\"type\":\"FunctionClauseError\",\"message\":\"no function clause matching in Enum.join/2\",\"backtrace\":[]}]"
+
+      expect(HTTPMock, :post, fn url, payload, _headers ->
+        assert payload =~ expected_payload_errors
+        send(caller, url: url, payload: payload)
+        {:ok, %{status_code: 204}}
+      end)
+
+      assert capture_log(fn ->
+               Logger.error(error_message)
+             end) =~ error_message
+
+      assert_receive(url: _url, payload: _http_payload)
+    end
+  end
+end

--- a/test/airbrake/logger_backend_test.exs
+++ b/test/airbrake/logger_backend_test.exs
@@ -11,6 +11,7 @@ defmodule Airbrake.LoggerBackendTest do
 
   setup do
     Logger.add_backend({LoggerBackend, :error})
+    Airbrake.start()
     :ok
   end
 

--- a/test/airbrake/worker_test.exs
+++ b/test/airbrake/worker_test.exs
@@ -86,8 +86,12 @@ defmodule Airbrake.WorkerTest do
   defp atomize_keys(other), do: other
 
   defp start_worker do
-    {:ok, worker_pid} = Airbrake.Worker.start_link()
-    worker_pid
+    start_result = Airbrake.Worker.start_link()
+
+    case start_result do
+      {:ok, worker_pid} -> worker_pid
+      {:error, {:already_started, worker_pid}} -> worker_pid
+    end
   end
 
   defp maybe_stop_worker do

--- a/test/airbrake/worker_test.exs
+++ b/test/airbrake/worker_test.exs
@@ -1,0 +1,63 @@
+defmodule Airbrake.WorkerTest do
+  use ExUnit.Case, async: false
+
+  import Mox
+
+  alias Airbrake.{HTTPMock, Payload}
+
+  setup [:set_mox_global, :verify_on_exit!]
+
+  setup do
+    {exception, stacktrace} =
+      try do
+        Enum.join(3, 'million')
+      rescue
+        exception -> {exception, System.stacktrace()}
+      end
+
+    [exception: exception, stacktrace: stacktrace]
+  end
+
+  describe "report/1" do
+    test "sends the exception and stacktrace to Airbrake", %{exception: exception, stacktrace: stacktrace} do
+      expected_payload =
+        exception
+        |> Payload.new(stacktrace)
+        |> Map.from_struct()
+
+      caller = self()
+
+      expect(HTTPMock, :post, fn url, payload, _headers ->
+        send(caller, url: url, payload: payload)
+        {:ok, %{status_code: 204}}
+      end)
+
+      Airbrake.Worker.report(exception)
+
+      assert_receive(url: url, payload: http_payload)
+
+      decoded_http_payload =
+        http_payload
+        |> Poison.decode!()
+        |> atomize_keys()
+
+      assert url =~ "/api/v3/projects/"
+      assert url =~ "/notices?key="
+      assert decoded_http_payload == expected_payload
+      assert decoded_http_payload == expected_payload
+    end
+  end
+
+  @spec atomize_keys(any()) :: map()
+  defp atomize_keys(map = %{}) do
+    map
+    |> Enum.map(fn {k, v} -> {String.to_existing_atom(k), atomize_keys(v)} end)
+    |> Enum.into(%{})
+  end
+
+  defp atomize_keys([head | rest]) do
+    [atomize_keys(head) | atomize_keys(rest)]
+  end
+
+  defp atomize_keys(other), do: other
+end

--- a/test/airbrake/worker_test.exs
+++ b/test/airbrake/worker_test.exs
@@ -8,12 +8,16 @@ defmodule Airbrake.WorkerTest do
   setup [:set_mox_global, :verify_on_exit!]
 
   setup do
+    start_worker()
+
     {exception, stacktrace} =
       try do
         Enum.join(3, 'million')
       rescue
         exception -> {exception, System.stacktrace()}
       end
+
+    on_exit(&maybe_stop_worker/0)
 
     [exception: exception, stacktrace: stacktrace]
   end
@@ -60,4 +64,26 @@ defmodule Airbrake.WorkerTest do
   end
 
   defp atomize_keys(other), do: other
+
+  defp start_worker do
+    {:ok, worker_pid} = Airbrake.Worker.start_link()
+    worker_pid
+  end
+
+  defp maybe_stop_worker do
+    pid_to_stop = GenServer.whereis(Airbrake.Worker)
+
+    case pid_to_stop do
+      nil -> :ok
+      _ -> stop_worker(pid_to_stop)
+    end
+  end
+
+  defp stop_worker(pid_to_stop) do
+    try do
+      GenServer.stop(pid_to_stop, :normal, 1_000)
+    catch
+      :exit, _ -> :ok
+    end
+  end
 end

--- a/test/airbrake_test.exs
+++ b/test/airbrake_test.exs
@@ -10,6 +10,7 @@ defmodule AirbrakeTest do
       {:ok, %{status_code: 204}}
     end)
 
+    Airbrake.start()
     :ok
   end
 

--- a/test/airbrake_test.exs
+++ b/test/airbrake_test.exs
@@ -1,5 +1,17 @@
 defmodule AirbrakeTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: false
+
+  import Mox
+
+  setup [:set_mox_global, :verify_on_exit!]
+
+  setup do
+    stub(Airbrake.HTTPMock, :post, fn _url, _payload, _headers ->
+      {:ok, %{status_code: 204}}
+    end)
+
+    :ok
+  end
 
   test "it doesn't raise errors if you send invalid arguments to Airbrake.report/2" do
     Airbrake.report(Enum, %{ignore: :this_error_in_test})

--- a/test/support/mocks.ex
+++ b/test/support/mocks.ex
@@ -1,0 +1,1 @@
+Mox.defmock(Airbrake.HTTPMock, for: HTTPoison.Base)

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,2 +1,3 @@
 ExUnit.start()
 Airbrake.start()
+Application.ensure_all_started(:mox)

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,3 +1,2 @@
 ExUnit.start()
-Airbrake.start()
 Application.ensure_all_started(:mox)


### PR DESCRIPTION
The main goal of the work in this change is to replace the deprecated `GenEvent` with Erlang's `:gen_event`. In support of that goal, the HTTP handler is set in test using a Mock handler with the [Mox library](https://hexdocs.pm/mox/Mox.html) while HTTPPoison is set as the HTTP handler outside of test. With a mock HTTP handler available, tests for `Airbrake.Worker.report/1` and `Airbrake.Worker.remember/1` are also aded.

## Replace deprecated `GenEvent` with Erlang's `:gen_event`

The `GenEvent` behaviour in Elixir is deprecated. When it is in use, `Airbrake.LoggerBackend` generates the following warning.

```
warning: GenEvent.__using__/1 is deprecated. Use one of the alternatives described in the documentation for the GenEvent module
  lib/airbrake/logger_backend.ex:3
```

Using `@behaviour :gen_event` is one of the suggested ways to replace `use GenEvent`. That replacement is done here: https://github.com/clifton-mcintosh/airbrake-elixir/blob/use_erlang_gen_event/lib/airbrake/logger_backend.ex#L4. 

```elixir
defmodule Airbrake.LoggerBackend do
  @moduledoc false

  @behaviour :gen_event
...
```

This is the central change in this pull request.

## Tests to increase confidence that replacement is safe

In order to increase confidence that replacing `use GenEvent` with `@behaviour :gen_event` in `Airbrake.LoggerBackend` is safe, tests were added to `Airbrake.LoggerBackend` prior to changing to verify that when the logger backend is set to `Airbrake.LoggerBackend` and an error is logged, it is correctly sent to the HTTP handler that is responsible for sending an error to Airbrake.

Once the tests were added (see https://github.com/romul/airbrake-elixir/commit/ae37114faccf4ce90506f7e8f0f73681ed4bf6ee), `use GenEvent` was replaced with `@behaviour :gen_event`. (See https://github.com/romul/airbrake-elixir/commit/323f01d56af004b57f7a0f39a788ee8eae9cf916).

## Tests for `Airbrake.Worker`

With a test HTTP handler in place, tests were also added for `Airbrake.Worker.report/1` and `Airbrake.Worker.remember/1`. The tests for `Airbrake.Worker.report/1` use the test HTTP handler to verify that the expected data are sent when a report is requested.

## Calling `Airbrake.start()` in specific tests

Because `Airbrake.Worker.remember/1` alters the state of the `Airbrake.Worker` module, having one version start up can present difficulties during testing. In particular, sometimes extra data would be present in other tests (for `Airbrake.Worker.report/1`) when the tests for `Airbrake.Worker.remember/1`. To remove this problem, testing is set to use the `--no-start` flag and tests that need `Airbrake.start()` to run have it explicitly invoked during setup.

Tests for the `Airbrake.Worker` module start and stop that module before and after each test so that state from one test does not affect the results of another one.

## Commit order
GitHub is listing commits out of order. When I run git log locally, this is the order I see:
```
* 3447672 (HEAD -> use_erlang_gen_event, origin/use_erlang_gen_event) Conditionally start worker
* 1b6b0ba Add test for Airbrake.Worker.remember
* ed71ca9 Explicitly start app for specific tests
* 6bf6d6f add test for Airbrake.Worker.report/1
* 323f01d use "@behaviour :gen_event" instead of "use GenEvent"
* ae37114 Add test for LoggerBackend
* b487b5a format Airbrake.LoggerBackend with "mix format"
* 25c0931 Use environment-specific adapter in Airbrake.Worker
* d74aa48 Set http adapter in environment-specific configs
* 8284c15 define mock for HTTPoison.Base
* 283e163 Add mox and ex_coveralls dependencies for testing
* 8b9ec45 (origin/master, origin/HEAD, master) Update README
```

That also matches the order of the commits when looking at the branch in GitHub. See https://github.com/clifton-mcintosh/airbrake-elixir/commits/use_erlang_gen_event.

The incorrect order in the pull request may be because I did some rebasing before pushing to GitHub.