### PR TITLE
Add :filter_headers option

### DIFF
--- a/lib/airbrake.ex
+++ b/lib/airbrake.ex
@@ -31,7 +31,8 @@ defmodule Airbrake do
             project_id: System.get_env("AIRBRAKE_PROJECT_ID"),
             environment: Mix.env,
             host: "https://airbrake.io", # or your Errbit host
-            filter_parameters: ["password"]
+            filter_parameters: ["password"],
+            filter_headers: ["authorization"]
 
           config :logger,
             backends: [:console, {Airbrake.LoggerBackend, :error}]
@@ -50,6 +51,7 @@ defmodule Airbrake do
     * `:host` - (binary) use it when you have an Errbit installation.
     * `:ignore` - (MapSet of binary or function returning boolean or :all) allows to ignore some or all exceptions.
     * `:filter_parameters` - (list of binaries) allows to filter out sensitive parameters such as passwords and tokens.
+    * `:filter_headers` - (list of binaries) list of attributes to be filtered from header in the environment of the payload.
 
   For `:api_key`, `:project_id` and `:environment` you could use a
   `{:system, "VAR_NAME"}` tuple. When given a tuple like `{:system, "VAR_NAME"}`,

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Airbrake.Mixfile do
   def project do
     [
       app: :airbrake,
-      version: "0.6.2",
+      version: "0.6.3",
       elixir: "~> 1.7",
       package: package(),
       description: """

--- a/test/airbrake/payload_test.exs
+++ b/test/airbrake/payload_test.exs
@@ -97,4 +97,21 @@ defmodule Airbrake.PayloadTest do
     assert "y" == payload.params["x"]
     Application.delete_env(:airbrake, :filter_parameters)
   end
+
+  test "it filters sensitive headers in the environment" do
+    Application.put_env(:airbrake, :filter_headers, ["authorization"])
+
+    payload =
+      get_payload(
+        env: %{
+          "headers" => %{"authorization" => "Bearer JWT", "x" => "y"},
+          "httpMethod" => "POST"
+        }
+      )
+
+    assert "[FILTERED]" == payload.environment["headers"]["authorization"]
+    assert "y" == payload.environment["headers"]["x"]
+    assert "POST" == payload.environment["httpMethod"]
+    Application.delete_env(:airbrake, :filter_headers)
+  end
 end

--- a/test/airbrake/payload_test.exs
+++ b/test/airbrake/payload_test.exs
@@ -92,8 +92,20 @@ defmodule Airbrake.PayloadTest do
 
   test "it filters sensitive params" do
     Application.put_env(:airbrake, :filter_parameters, ["password"])
-    payload = get_payload(params: %{"password" => "top_secret", "x" => "y"})
+
+    payload =
+      get_payload(
+        params: %{
+          "password" => "top_secret",
+          "x" => "y",
+          "variables" => %{"password" => "super_secret"},
+          "data" => [%{"password" => "classified"}]
+        }
+      )
+
     assert "[FILTERED]" == payload.params["password"]
+    assert "[FILTERED]" == payload.params["variables"]["password"]
+    assert "[FILTERED]" == payload.params["data"] |> Enum.at(0) |> Map.get("password")
     assert "y" == payload.params["x"]
     Application.delete_env(:airbrake, :filter_parameters)
   end


### PR DESCRIPTION
The `Airbrake.Plug` by default includes _all_ HTTP headers in the "Environment" of the Airbrake report.  This can sometimes include an `"authorization"` header (and possibly other sensitive data).

![Screen Shot 2020-11-10 at 11 40 05 AM](https://user-images.githubusercontent.com/6766/98733604-63076f00-2366-11eb-83d7-f924c5175b7a.png)

I added a new configuration option `:filter_headers` to work similar to `:filter_parameters`.  `:filter_headers` is a list of binaries, the names of headers to be filtered.

