### PR TITLE
Set sane default values for filter params #15

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -3,4 +3,6 @@ use Mix.Config
 config :airbrake,
   api_key: {:system, "AIRBRAKE_API_KEY", "FAKEKEY"},
   project_id: {:system, "AIRBRAKE_PROJECT_ID", 0},
-  host: {:system, "AIRBRAKE_HOST", "https://airbrake.io"}
+  host: {:system, "AIRBRAKE_HOST", "https://airbrake.io"},
+  filter_parameters: ["password"],
+  filter_headers: ["authorization"]


### PR DESCRIPTION
Set filter_parameters to ["password"], and filter_headers to ["authorization"].